### PR TITLE
Trigger the 'latest' image push on GH triggers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
           ./prod-build.sh
 
       - name: Push container image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' || github.event_name == 'repository_dispatch') && github.ref == 'refs/heads/main'
         run: |
           docker push quay.io/apicurio/apicurio-registry-mt-ui:latest
 


### PR DESCRIPTION
The image is built but not pushed:
https://github.com/Apicurio/apicurio-registry-mt-ui/actions/runs/3063841642/jobs/4946361427